### PR TITLE
add -firehose option to kinesis-cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ kinesis-tailf supports decoding packed records by Kinesis Producer Library (KPL)
 
 ## kinesis-cat
 
-cat command for putting data to Amazon Kinesis Data Streams.
+cat command for putting data to Amazon Kinesis Data Streams or Kinesis Data Firehose.
 
 ```
 Usage of kinesis-cat:
+  -firehose
+    	put to Firehose delivery stream
   -lf
     	append LF(\n) to each record
   -partition-key string

--- a/cat.go
+++ b/cat.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/aws/aws-sdk-go/service/firehose"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 )
 
@@ -28,6 +29,30 @@ func (app *App) Cat(ctx context.Context, partitionKey string, src io.Reader) err
 			in.PartitionKey = &partitionKey
 		}
 		if _, err := app.kinesis.PutRecord(in); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (app *App) CatFirehose(ctx context.Context, _ string, src io.Reader) error {
+	fh := firehose.New(app.sess)
+	scanner := bufio.NewScanner(src)
+	for scanner.Scan() {
+		b := scanner.Bytes()
+		if app.AppendLF {
+			b = append(b, LF...)
+		}
+		in := &firehose.PutRecordInput{
+			Record: &firehose.Record{
+				Data: b,
+			},
+			DeliveryStreamName: &app.StreamName,
+		}
+		if _, err := fh.PutRecord(in); err != nil {
 			return err
 		}
 	}

--- a/kinesis.go
+++ b/kinesis.go
@@ -36,6 +36,7 @@ type timeOverFunc func(time.Time) bool
 
 type App struct {
 	kinesis    *kinesis.Kinesis
+	sess       *session.Session
 	StreamName string
 	AppendLF   bool
 }
@@ -43,6 +44,7 @@ type App struct {
 func New(sess *session.Session, name string) *App {
 	return &App{
 		kinesis:    kinesis.New(sess),
+		sess:       sess,
 		StreamName: name,
 	}
 }


### PR DESCRIPTION
`kinesis-cat -firehose` puts records to Kinesis Data Firehose instead of Data Streams.

